### PR TITLE
docs: clarify coverage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,10 @@
 ## Project Structure & Modules
 
 - Java 21 + Spring Boot 3 (Gradle).
-- Source: `src/main/java/bunny/boardhole/**` organized by domain: `auth`, `user`, `board`, `shared`.
+- Source: `src/main/java/dev/xiyo/bunnyholes/boardhole/**` organized by domain: `auth`, `board`, `user`, `shared`, `web`.
 - Layers per domain: `presentation` → `application` → `domain` → `infrastructure`.
 - Web assets: `src/main/resources/static/assets/**`.
-- Tests: `src/test/java/bunny/boardhole/**` (JUnit 5, Testcontainers, RestAssured).
+- Tests: `src/test/java/dev/xiyo/bunnyholes/boardhole/**` (JUnit 5, Testcontainers, RestAssured).
 
 ## Build, Test, Run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ presentation → application → domain → infrastructure
 ### Domain Pattern
 
 ```
-bunny.boardhole.[domain]/
+dev/xiyo/bunnyholes/boardhole/[domain]/
 ├── application/
 │   ├── command/     # Write operations (Commands + CommandService)
 │   ├── query/       # Read operations (QueryService)
@@ -57,6 +57,8 @@ bunny.boardhole.[domain]/
     ├── dto/         # Request/Response DTOs
     └── mapper/      # MapStruct mappers (Result ↔ Response)
 ```
+
+`web` 도메인은 서버 렌더링 뷰와 정적 리소스를 다루며 `presentation`과 `view` 하위 디렉터리로 구성됩니다.
 
 ## Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,14 @@ src/main/java/dev/xiyo/bunnyholes/boardhole/
 │   ├── domain/
 │   ├── infrastructure/
 │   └── presentation/
-└── shared/        # 공통 모듈
-    ├── config/
-    ├── constants/
-    ├── exception/
-    └── security/
+├── shared/        # 공통 모듈
+│   ├── config/
+│   ├── constants/
+│   ├── exception/
+│   └── security/
+└── web/           # Thymeleaf 기반 웹 뷰와 정적 리소스 조립
+    ├── presentation/
+    └── view/
 ```
 
 **레이어드 아키텍처**:
@@ -163,9 +166,6 @@ src/main/java/dev/xiyo/bunnyholes/boardhole/
 
 # E2E 테스트만 실행
 ./gradlew e2eTest
-
-# 테스트 커버리지 확인
-./gradlew jacocoTestReport
 ```
 
 **테스트 구성**:
@@ -173,6 +173,7 @@ src/main/java/dev/xiyo/bunnyholes/boardhole/
 - **Integration Tests**: 통합 테스트 (Testcontainers 사용)
 - **E2E Tests**: 전체 시스템 테스트
 - **Architecture Tests**: ArchUnit으로 아키텍처 규칙 검증
+- **Coverage**: 현재 별도 커버리지 리포트는 제공되지 않습니다.
 
 ## 🔧 유용한 명령어
 


### PR DESCRIPTION
## Summary
- update the README coverage note to simply state that coverage reports are not currently available, avoiding references to removed tooling

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68db8b774f40832da6fe790852c8d204